### PR TITLE
📂 Adds pre build step to insure project structure

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -52,6 +52,7 @@ lib_deps =
 	; plageoj/UrlEncode@ ^1.0.1
 ; board_build.partitions = config/no_oat.csv
 extra_scripts = 
+	pre:scripts/pre_build.py
     pre:scripts/build_app.py
     pre:scripts/generate_cert_bundle.py
     scripts/rename_fw.py

--- a/esp32/scripts/pre_build.py
+++ b/esp32/scripts/pre_build.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+Import("env")
+
+filesystem_dir = env["PROJECT_DIR"] + "/data"
+
+Path(filesystem_dir).mkdir(exist_ok=True)


### PR DESCRIPTION
# Purpose
New projects can't build (#42) as the data folder is not tracked to keep user generate files from being committed.

## Description
Adds new pre build script to ensure the data folder exist.