### PR TITLE
🪇 Reduces kinematics calculations

### DIFF
--- a/esp32/features.ini
+++ b/esp32/features.ini
@@ -7,7 +7,7 @@ build_flags =
   -D FT_UPLOAD_FIRMWARE=0
   -D FT_DOWNLOAD_FIRMWARE=0
   -D FT_ANALYTICS=1
-  -D FT_MOTION=0
+  -D FT_MOTION=1
 
   ; Hardware specific
   -D FT_IMU=0

--- a/esp32/lib/ESP32-sveltekit/MotionService.h
+++ b/esp32/lib/ESP32-sveltekit/MotionService.h
@@ -108,7 +108,6 @@ class MotionService
     }
 
     bool updateMotion() {
-        float new_angles[12] = {0,};
         switch (motionState) {
             case MOTION_STATE::IDLE:
                 return false;
@@ -160,6 +159,7 @@ class MotionService
     constexpr static int MotionInterval = 100;
 
     body_state_t body_state = {0,};
+    float new_angles[12] = {0,};
 
     float dir[12] = {-1, -1, -1, 1, -1, -1, -1, -1, -1, 1, -1, -1};
     float default_feet_positions[4][4] = {


### PR DESCRIPTION
# Purpose
If the bodystate remains equal between loops, the calculation with end with the same angles. Therefor an quick performance optimization is to skip the calculations