### PR TITLE
Support for esp32s3 PSRAM

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -41,6 +41,8 @@ board_upload.flash_size = 16MB
 upload_speed = 1000000
 build_flags =
 	${env.build_flags}
+	-DBOARD_HAS_PSRAM
+	-mfix-esp32-psram-cache-issue
 	-D FT_CAMERA=1
 	-D CAMERA_MODEL_ESP32S3_EYE=1
 	-D WS2812_PIN=48


### PR DESCRIPTION
# Purpose
- Adds the necessary build flags to enable PSRAM for the esp32s3 n16r8