### PR TITLE
🚇 Adds hasSubcribers to event socket for early return

### DIFF
--- a/esp32/lib/ESP32-sveltekit/AnalyticsService.h
+++ b/esp32/lib/ESP32-sveltekit/AnalyticsService.h
@@ -39,6 +39,7 @@ class AnalyticsService {
     TaskManager *_taskManager;
 
     void updateAnalytics() {
+        if (!_socket->hasSubscribers(EVENT_ANALYTICS)) return;
         doc.clear();
         doc["uptime"] = millis() / 1000;
         doc["free_heap"] = ESP.getFreeHeap();

--- a/esp32/lib/ESP32-sveltekit/EventSocket.cpp
+++ b/esp32/lib/ESP32-sveltekit/EventSocket.cpp
@@ -125,6 +125,8 @@ esp_err_t EventSocket::onFrame(PsychicWebSocketRequest *request, httpd_ws_frame 
     return ESP_OK;
 }
 
+bool EventSocket::hasSubscribers(const char *event) { return !client_subscriptions[event].empty(); }
+
 void EventSocket::emit(const char *event, const char *payload, const char *originId, bool onlyToSameOrigin) {
     int originSubscriptionId = originId[0] ? atoi(originId) : -1;
     xSemaphoreTake(clientSubscriptionsMutex, portMAX_DELAY);

--- a/esp32/lib/ESP32-sveltekit/EventSocket.h
+++ b/esp32/lib/ESP32-sveltekit/EventSocket.h
@@ -22,6 +22,8 @@ class EventSocket {
 
     void begin();
 
+    bool hasSubscribers(const char *event);
+
     void onEvent(String event, EventCallback callback);
 
     void onSubscribe(String event, SubscribeCallback callback);


### PR DESCRIPTION
# Purpose
* Adds a `hasSubscribers` bool to check whether there is clients that is subscribed to the event thats about to be emitted.

The checks makes is possible to skip a lot of redundant calculations and  serialization.

Eg:
```c++
  if (!socket->hasSubscribers(EVENT_WITH_HEAVY_CALC)) return;
  (...) // a lot of heavy calculations
```