### PR TITLE
🪮 Moves imu definition to own service

### DIFF
--- a/esp32/lib/ESP32-sveltekit/peripherals/imu.h
+++ b/esp32/lib/ESP32-sveltekit/peripherals/imu.h
@@ -1,0 +1,66 @@
+#ifndef IMU_h
+#define IMU_h
+
+#include <list>
+#include <SPI.h>
+#include <Wire.h>
+#include <ArduinoJson.h>
+#include <MathUtils.h>
+
+#include <MPU6050_6Axis_MotionApps612.h>
+
+class IMU {
+  public:
+    IMU() {}
+    bool initialize() {
+        _imu.initialize();
+        imu_success = _imu.testConnection();
+        devStatus = _imu.dmpInitialize();
+        if (!imu_success) return false;
+        _imu.setDMPEnabled(true);
+        _imu.setI2CMasterModeEnabled(false);
+        _imu.setI2CBypassEnabled(true);
+        _imu.setSleepEnabled(false);
+        return true;
+    }
+
+    bool readIMU() {
+        if (!imu_success) return false;
+        bool updated = _imu.dmpGetCurrentFIFOPacket(fifoBuffer);
+        _imu.dmpGetQuaternion(&q, fifoBuffer);
+        _imu.dmpGetGravity(&gravity, &q);
+        _imu.dmpGetYawPitchRoll(ypr, &q, &gravity);
+        return updated;
+    }
+
+    float getTemperature() { return imu_success ? imu_temperature : -1; }
+
+    float getAngleX() { return imu_success ? ypr[0] * 180 / M_PI : 0; }
+
+    float getAngleY() { return imu_success ? ypr[1] * 180 / M_PI : 0; }
+
+    float getAngleZ() { return imu_success ? ypr[2] * 180 / M_PI : 0; }
+
+    Quaternion* getQuaternion() { return &q; }
+
+    void readIMU(JsonObject& root) {
+        if (!imu_success) return;
+        root["x"] = round2(getAngleX());
+        root["y"] = round2(getAngleY());
+        root["z"] = round2(getAngleZ());
+    }
+
+    bool active() { return imu_success; }
+
+  private:
+    MPU6050 _imu;
+    bool imu_success {false};
+    uint8_t devStatus {false};
+    Quaternion q;
+    uint8_t fifoBuffer[64];
+    VectorFloat gravity;
+    float ypr[3];
+    float imu_temperature {-1};
+};
+
+#endif


### PR DESCRIPTION
# Purpose
By moving IMU code to own file, we clean up peripherals allowing it to act more as a facade and mediator.
It can now focus on controlling access to the I2C bus and interface with peripherals
This also makes it easier to do sensor fusion later on.


## Note
We also move around to other function to fix their scoping