### PR TITLE
📦 Moves platformoi.ini to root

### DIFF
--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -2,20 +2,19 @@ name: PlatformIO CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     paths:
-        - 'esp32/**'  
+      - "esp32/**"
+      - "platformio.ini"
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths:
-        - 'esp32/**'  
+      - "esp32/**"
+      - "platformio.ini"
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./esp32
 
     steps:
       - uses: actions/checkout@v3
@@ -28,8 +27,8 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
-      - run: pip install -r ./scripts/requirements.txt
+          python-version: "3.x"
+      - run: pip install -r esp32/scripts/requirements.txt
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pio

--- a/esp32/factory_settings.ini
+++ b/esp32/factory_settings.ini
@@ -7,7 +7,7 @@
 [factory_settings]
 build_flags =
     -D APP_NAME=\"Spot-Micro\" ; [a-zA-Z0-9-_]
-    -D APP_VERSION=\"0.0.1\"
+    -D APP_VERSION=\"0.1.0\"
 
     ; WiFi settings
     -D FACTORY_WIFI_SSID=\"\"

--- a/esp32/scripts/build_app.py
+++ b/esp32/scripts/build_app.py
@@ -26,8 +26,8 @@ Import("env")
 project_dir = env["PROJECT_DIR"]
 buildFlags = env.ParseFlags(env["BUILD_FLAGS"])
 
-interface_dir = project_dir + "/../app"
-output_file = project_dir + "/lib/ESP32-sveltekit/WWWData.h"
+interface_dir = project_dir + "/app"
+output_file = project_dir + "/esp32/lib/ESP32-sveltekit/WWWData.h"
 source_www_dir = interface_dir + "/src"
 build_dir = interface_dir + "/build"
 filesystem_dir = project_dir + "/data/www"

--- a/esp32/scripts/generate_cert_bundle.py
+++ b/esp32/scripts/generate_cert_bundle.py
@@ -36,8 +36,8 @@ except ImportError:
 ca_bundle_bin_file = 'x509_crt_bundle.bin'
 mozilla_cacert_url = 'https://curl.se/ca/cacert.pem'
 adafruit_cacert_url = 'https://raw.githubusercontent.com/adafruit/certificates/main/data/roots.pem'
-certs_dir = Path("./ssl_certs")
-binary_dir = Path("./src/certs")
+certs_dir = Path("./esp32/ssl_certs")
+binary_dir = Path("./esp32/src/certs")
 
 quiet = False
 

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -3,6 +3,7 @@
 DRAM_ATTR Spot spot;
 
 void IRAM_ATTR SpotControlLoopEntry(void*) {
+    ESP_LOGI("main", "Setup complete now runing tsk");
     TickType_t xLastWakeTime = xTaskGetTickCount();
     const TickType_t xFrequency = 10 / portTICK_PERIOD_MS;
     for (;;) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,13 +10,16 @@
 
 [platformio]
 description = Spot Micro Robot
-data_dir = data
+data_dir = esp32/data
+src_dir = esp32/src
+include_dir = esp32/include
+lib_dir = esp32/lib
 extra_configs = 
-	factory_settings.ini
-	features.ini
-	build_settings.ini
+	esp32/factory_settings.ini
+	esp32/features.ini
+	esp32/build_settings.ini
 build_cache_dir = .pio/build_cache
-default_envs = esp32-camera ; Change this to your default environment example: [env:{esp32-camera}]
+default_envs = esp32-camera
 
 ; ================================================================
 ; Project environments
@@ -112,6 +115,7 @@ lib_deps =
 	adafruit/Adafruit BMP085 Unified@^1.1.3
 	adafruit/Adafruit ADS1X15@^2.5.0
 	adafruit/Adafruit Unified Sensor@^1.1.14
+    adafruit/Adafruit BNO055@^1.6.4
 	fastled/FastLED@^3.7.0
     SPI
 	FS
@@ -124,10 +128,10 @@ lib_deps =
 	WiFiClientSecure
 	HTTPUpdate
 extra_scripts = 
-	pre:scripts/pre_build.py
-    pre:scripts/build_app.py
-    pre:scripts/generate_cert_bundle.py
-    scripts/rename_fw.py
-board_build.embed_files = src/certs/x509_crt_bundle.bin	
+	pre:esp32/scripts/pre_build.py
+    pre:esp32/scripts/build_app.py
+    pre:esp32/scripts/generate_cert_bundle.py
+    esp32/scripts/rename_fw.py
+board_build.embed_files = esp32/src/certs/x509_crt_bundle.bin	
 board_ssl_cert_source = adafruit
 lib_compat_mode = strict


### PR DESCRIPTION
# Purpose
As the platformio.ini files is in a sub folder, you have to open that subfolder in order to use the PlatformIO extenstion.

By moving it in to root, you have open only the root of the repo