### PR TITLE
⏱️ Faster control loop

### DIFF
--- a/esp32/lib/ESP32-sveltekit/settings/peripherals_settings.h
+++ b/esp32/lib/ESP32-sveltekit/settings/peripherals_settings.h
@@ -14,7 +14,7 @@
 #define SCL_PIN SCL
 #endif
 #ifndef I2C_FREQUENCY
-#define I2C_FREQUENCY 100000UL
+#define I2C_FREQUENCY 1000000UL
 #endif
 
 class PinConfig {

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -5,7 +5,7 @@ DRAM_ATTR Spot spot;
 void IRAM_ATTR SpotControlLoopEntry(void*) {
     ESP_LOGI("main", "Setup complete now runing tsk");
     TickType_t xLastWakeTime = xTaskGetTickCount();
-    const TickType_t xFrequency = 10 / portTICK_PERIOD_MS;
+    const TickType_t xFrequency = 5 / portTICK_PERIOD_MS;
     for (;;) {
         spot.readSensors();
         spot.planMotion();

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -20,7 +20,7 @@ void setup() {
 
     spot.initialize();
 
-    g_taskManager.createTask(SpotControlLoopEntry, "Spot control task", 4096, nullptr, 3);
+    g_taskManager.createTask(SpotControlLoopEntry, "Spot control task", 4096, nullptr, 5);
 }
 
 void loop() { vTaskDelete(NULL); }

--- a/platformio.ini
+++ b/platformio.ini
@@ -109,7 +109,7 @@ lib_deps =
 	adafruit/Adafruit SSD1306@^2.5.7
 	adafruit/Adafruit GFX Library@^1.11.5
 	adafruit/Adafruit BusIO@^1.9.3
-	adafruit/Adafruit PWM Servo Driver Library@^2.4.1
+	https://github.com/runeharlyk/Adafruit-PWM-Servo-Driver-Library.git
 	adafruit/Adafruit ST7735 and ST7789 Library@^1.10.4
 	adafruit/Adafruit HMC5883 Unified@^1.2.3
 	adafruit/Adafruit BMP085 Unified@^1.1.3


### PR DESCRIPTION
# Purpose
The faster the main control loop, the smoother the robot.

In this pr I introduces the following changes to improve the speed:
- Faster I2C clock speed. Now 1MHz fast mode plus
- Bulk updating of PWM servo values. The Adafruit PCA driver only support single, therefor I introduce a new function for bulk update which mean we remove 11 separate I2C transmission per loop
- The priority of the main control loop is update to 5 from 3.
- Updates the control loop frequency to 200 hz from 100 hz

When running the loop a 1000 Hz we got around 750 calls. With these changes we get 1000 / 1000